### PR TITLE
fix(channel): unregister session channels on close so remote numbers can be reused

### DIFF
--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SessionChannel.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SessionChannel.kt
@@ -215,6 +215,12 @@ class SessionChannel internal constructor(
         // Channel is gone; if the server never reported an exit, resolve
         // waiters with "unknown" rather than leaving them suspended.
         _exitInfo.complete(null)
+        // Release the local/remote numbers now the lifecycle is CLOSED, so the
+        // server may legally reuse this remote number for the next channel
+        // (RFC 4254 §5.3). Every path into here is terminal — receiving CLOSE,
+        // or disconnect — and unregistering an already-removed entry is a no-op,
+        // so the connection-wide teardown in disconnectAll() stays safe.
+        connection.unregisterSessionChannel(localChannelNumber)
     }
 
     internal suspend fun onDisconnected() {

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
@@ -356,6 +356,16 @@ class SshConnection(
     private val _disconnectedFlow = MutableSharedFlow<Throwable?>(extraBufferCapacity = 1)
     val disconnectedFlow: SharedFlow<Throwable?> = _disconnectedFlow.asSharedFlow()
 
+    /**
+     * Whether a session channel has ever been established on this connection.
+     *
+     * [checkAllChannelsClosed] used to infer this from a *closed* session channel still sitting in
+     * the registry. Closed channels are now unregistered so the server may reuse their channel
+     * numbers, so the fact is recorded explicitly instead of being a side effect of the leak.
+     */
+    @Volatile
+    private var hadSessionChannel = false
+
     private var serverVersion: String? = null
     private var clientKexInit: ByteArray? = null
     private var serverKexInit: ByteArray? = null
@@ -2320,6 +2330,19 @@ class SshConnection(
         channelRegistry.unregister(channel.localChannelNumber)
     }
 
+    /**
+     * Releases a session channel's local and remote numbers once its lifecycle has reached
+     * [org.connectbot.sshlib.protocol.SshChannelState.CLOSED].
+     *
+     * Without this the registry keeps the closed channel's remote number indexed forever, so the
+     * next channel the server confirms with that number — legal to reuse per RFC 4254 §5.3 once
+     * both sides have sent CHANNEL_CLOSE — is rejected with "Remote channel N is already
+     * registered", taking the whole connection down with it.
+     */
+    internal fun unregisterSessionChannel(localChannelNumber: Int) {
+        channelRegistry.unregister(localChannelNumber)
+    }
+
     internal suspend fun sendChannelOpenConfirmationPublic(
         recipientChannel: Int,
         senderChannel: Int,
@@ -2884,8 +2907,13 @@ class SshConnection(
     private suspend fun checkAllChannelsClosed() {
         val established = channelRegistry.establishedSnapshot()
         val allClosed = established.all { !it.isOpen }
-        logger.debug("checkAllChannelsClosed: established=${established.size}, allClosed=$allClosed")
-        if (allClosed && established.any { it.kind == SshChannelRegistry.Kind.SESSION }) {
+        logger.debug(
+            "checkAllChannelsClosed: established=${established.size}, allClosed=$allClosed, " +
+                "hadSessionChannel=$hadSessionChannel",
+        )
+        // Previously this asked whether a SESSION entry was still present, which only held because
+        // closed channels were never unregistered. Now that they are, ask the question directly.
+        if (allClosed && hadSessionChannel) {
             logger.info("All channels closed, sending disconnect")
             sendDisconnect()
         }
@@ -3076,6 +3104,7 @@ class SshConnection(
         val pending = channelRegistry.findPendingSession(localChannelNumber)
             ?: error("Pending session channel $localChannelNumber disappeared before promotion")
         channelRegistry.promote(pending, channel)
+        hadSessionChannel = true
         logger.debug("Session channel registered: local=$localChannelNumber, remote=$remoteChannelNumber")
 
         return channel

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/client/SessionChannelTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/client/SessionChannelTest.kt
@@ -21,6 +21,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -257,5 +258,29 @@ class SessionChannelTest {
         channel.sendEof()
 
         coVerify(exactly = 1) { conn.sendChannelEof(1) }
+    }
+
+    @Test
+    fun `receiving CLOSE unregisters the channel so its remote number can be reused`() = runTest {
+        val (channel, connection) = createChannel()
+
+        channel.onClose()
+
+        // The registry indexes channels by the SERVER's channel number. Leaving a
+        // closed channel registered means the next channel the server confirms
+        // with that number - legal to reuse once both sides have sent
+        // CHANNEL_CLOSE (RFC 4254 section 5.3) - is rejected with "Remote channel
+        // N is already registered", which fails the open AND tears down the whole
+        // connection.
+        verify { connection.unregisterSessionChannel(0) }
+    }
+
+    @Test
+    fun `disconnect unregisters the channel too`() = runTest {
+        val (channel, connection) = createChannel()
+
+        channel.onDisconnected()
+
+        verify { connection.unregisterSessionChannel(0) }
     }
 }


### PR DESCRIPTION
Fixes #238.

## The bug

`SessionChannel` never unregisters itself. Forwarding channels are removed via `unregisterForwardingChannel`, and an agent channel is removed on its open-failure path, but a session channel stays in `SshChannelRegistry` for the life of the connection — keeping its entry in `localRecipientByRemoteRecipient`.

Once the server reuses that remote number for the next channel — legal after both sides have sent `CHANNEL_CLOSE` (RFC 4254 §5.3) — `bindRemoteRecipient` rejects it:

```
IllegalStateException: Remote channel 1 is already registered
```

…and because that surfaces inside the packet loop, the whole connection goes down rather than just the new channel. Against Apache MINA sshd the second `openSession()` just returns `null` instead, which is why the issue lists two symptoms.

## The fix

`closeResources()` now releases the channel. Every path into it is terminal — receiving `CLOSE`, or disconnect — and unregistering an already-removed entry is a no-op, so the connection-wide `disconnectAll()` stays safe.

## The part worth your eyes

`checkAllChannelsClosed()` was inferring *"this connection carried a session"* from a **closed session still sitting in the registry** — i.e. from the leak itself:

```kotlin
if (allClosed && established.any { it.kind == SshChannelRegistry.Kind.SESSION })
```

Once channels are properly released that signal disappears, the client stops sending its clean disconnect, and `disconnectedFlow` never emits. Your existing integration test `disconnectedFlow emits when server closes channel` caught this immediately — it passed on a clean tree and failed with my first version of the fix.

So the fact is now recorded explicitly:

```kotlin
if (allClosed && hadSessionChannel)
```

One behavioural nuance to flag rather than bury: the old condition required a session entry to still be *present*, the new one asks whether a session ever *existed*. These differ in one case — a session opens and closes, then only forwarding channels remain and later close. Previously that would not have triggered the clean disconnect; now it does. That seemed closer to the intent, but it is your call and I'm happy to scope it to `hadSessionChannel && established.any { … }` if you'd rather preserve the exact prior behaviour.

## Testing

- Two regression tests added to `SessionChannelTest` (receive-CLOSE and disconnect paths). **Both verified to fail without the fix** — I reverted the one-line change and re-ran to confirm they actually gate the bug rather than passing vacuously.
- Full `:sshlib:test` green locally, including the Testcontainers integration tests.
- Also verified end-to-end from the downstream side: the original reproduction (an Android client running repeated `exec` over one long-lived connection against real OpenSSH) no longer collides.

## Notes

- `AgentChannel` looks like it has the same shape — no unregister on its close path, only on open-failure. I've left it alone since I have no way to exercise agent forwarding here; happy to extend the fix if you'd like it in the same PR.
- `spotlessApply` rewrites a large part of the tree on a clean checkout here (some tool-version drift), so I've kept the diff to only the three files I touched.
